### PR TITLE
Refactor Google Play Dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -120,5 +120,6 @@ idea {
     }
 }
 dependencies {
-    compile 'com.google.android.gms:play-services:9.8.00'
+    compile 'com.google.android.gms:play-services-ads:9.8.0'
+    compile 'com.google.android.gms:play-services-auth:9.8.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,6 @@ project(":core") {
     dependencies {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
         compile 'org.apache.commons:commons-lang3:3.4'
-        //compile 'com.google.android.gms:play-services-games:9.8.00'
 
         // Test dependencies.
         testCompile "junit:junit:4.11"


### PR DESCRIPTION
Update dependencies to only use Authentication services and Ads for now. We should add the dependencies individually as we need them.